### PR TITLE
Use capitalcase for X-Consul-Token not lowercase

### DIFF
--- a/v1/acl/token/self
+++ b/v1/acl/token/self
@@ -1,7 +1,7 @@
 ${ env('CONSUL_ACLS_LEGACY', false) ? `rpc error making call: rpc: can't find method ACL.Method` : `
 {
   "AccessorID": "${fake.random.uuid()}",
-  "SecretID": ${typeof headers['x-consul-token'] !== 'undefined' ? '"' + headers['x-consul-token'] + '"' : null},
+  "SecretID": ${typeof headers['X-Consul-Token'] !== 'undefined' ? '"' + headers['X-Consul-Token'] + '"' : null},
   "Namespace": "${
     typeof location.search.ns !== 'undefined' ? location.search.ns :
       typeof http.body.Namespace !== 'undefined' ? http.body.Namespace : 'default'


### PR DESCRIPTION
This changes the retrieval of the `X-Consul-Token` header to use capital case instead of lower case.

In the Consul UI it's not affected us in the past as we've always used what the user entered as the 'truth' rather than what is returned by the API. 