### PR TITLE
Make things so you get a service (or service combo) of every type

### DIFF
--- a/v1/internal/ui/services
+++ b/v1/internal/ui/services
@@ -65,6 +65,9 @@ ${typeof location.search.ns !== 'undefined' ? `
                     )
                 }
             ],
+${kind === 'connect-proxy' ? `
+            "ProxyFor": ["service-${i - 1}"],
+` : `` }
 ${kind !== '' ? `
             "Kind": "${kind}",
 ` : `` }

--- a/v1/internal/ui/services
+++ b/v1/internal/ui/services
@@ -1,3 +1,9 @@
+${[0].map(
+  () => {
+    let prevKind;
+    let name;
+    const gateways = ['mesh-gateway', 'ingress-gateway', 'terminating-gateway'];
+    return `
 [
   ${
     range(
@@ -12,9 +18,28 @@
     ).map(
       function(item, i)
       {
-        const kind = fake.helpers.randomize(['', 'connect-proxy', 'mesh-gateway', 'ingress-gateway', 'terminating-gateway']);
-        const name = `service-${i}${ kind !== '' ? `-${kind.replace('connect-', '')}` : '' }`;
-        
+        let kind;
+        switch(i) {
+          case 0:
+            kind = '';
+            break;
+          case 1:
+            kind = 'connect-proxy';
+            break;
+          case 2:
+          case 3:
+          case 4:
+            kind = gateways[i - 2];
+            break;
+          default:
+            kind = prevKind === '' ? fake.helpers.randomize(['connect-proxy', '']) : fake.helpers.randomize(['', '', '', ''].concat(gateways));
+        }
+        prevKind = kind;
+        if(kind === 'connect-proxy') {
+          name = `${name}-proxy`;
+        } else {
+          name = `service-${i}${ kind !== '' ? `-${kind.replace('connect-', '')}` : '' }`;
+        }
         return `
           {
             "Name":"${name}",
@@ -43,7 +68,7 @@ ${typeof location.search.ns !== 'undefined' ? `
 ${kind !== '' ? `
             "Kind": "${kind}",
 ` : `` }
-            "InstanceCount": ${fake.random.number({min: 1, max: 4000})},
+            "InstanceCount": ${fake.helpers.randomize([fake.random.number({min: 1, max: 4000}), fake.random.number({min: 1, max: 90}), fake.random.number({min: 1, max: 10})])},
 ${ fake.random.number({min: 1, max: 10}) > 2 ? `
             "ExternalSources": [
                 ${
@@ -76,3 +101,4 @@ ${ fake.random.number({min: 1, max: 10}) > 2 ? `
     )
   }
 ]
+`})}


### PR DESCRIPTION
I noticed that its sometimes difficult to see every type of service (and its design) in the service listing. So I made it less-random-but-still-random.

I've not checked with with existing tests as yet, and ideally it shouldn't affect anything existing.

PRing this for visibility for the moment