### PR TITLE
Mirror the icons/kinds available in the backend

### DIFF
--- a/v1/internal/ui/oidc-auth-methods
+++ b/v1/internal/ui/oidc-auth-methods
@@ -15,7 +15,7 @@ return `
   {
     "Name": "${name.split(' ').join('-').toLowerCase()}",
     "DisplayName": "${name}",
-    "Kind": "${fake.helpers.randomize(['okta', 'auth0', 'gitlab', 'aws', 'azure', 'bitbucket', 'gcp'])}",
+    "Kind": "${fake.helpers.randomize(['no-icon', 'google', 'okta', 'auth0', 'microsoft'])}",
     "Namespace": "default"
   }
 `})


### PR DESCRIPTION
'no-icon' was added to ensure we can show one with no icon properly