### PR TITLE
Update addresses to always return hostname:port

### DIFF
--- a/v1/internal/ui/gateway-services-nodes/_
+++ b/v1/internal/ui/gateway-services-nodes/_
@@ -56,10 +56,10 @@ ${ fake.random.number({min: 1, max: 10}) > 2 ? `
     "GatewayConfig": {
       "Addresses": [
         ${
-          range(fake.random.number(5)).map(
+          range(fake.random.number(6)).map(
             function(item, i)
             {
-              return `"${fake.random.number({min: 1, max: 10}) > 2 ? `*.${fake.internet.domainName()}`: ``}:${fake.random.number({min: 0, max: 65535})}"`;
+              return `"${fake.random.number({min: 1, max: 10}) > 8 ? `*.`: ``}${fake.internet.domainName()}:${fake.random.number({min: 0, max: 65535})}"`;
             }
           )
         }


### PR DESCRIPTION
Freddy advised addresses will always be `hostname:port` and sometimes they will have a `*.`.

<img width="259" alt="Screen Shot 2020-06-24 at 3 41 05 PM" src="https://user-images.githubusercontent.com/19161242/85620130-57bedb80-b631-11ea-9760-2ac2806d881a.png">
