### PR TITLE
Update topology endpoint to return the same datacenter as current Service

### DIFF
--- a/v1/internal/ui/topology/_
+++ b/v1/internal/ui/topology/_
@@ -1,20 +1,29 @@
+${
+  [1].map(() => {
+    const dc = location.search.dc;
+    const serviceCount = env(
+      'CONSUL_SERVICE_COUNT',
+      Math.floor(
+        (
+          Math.random() * env('CONSUL_SERVICE_MAX', 10)
+        ) + parseInt(env('CONSUL_SERVICE_MIN', 1))
+      )
+    );
+    return `
 {
   "Upstreams":
   [
     ${
       range(
-        env(
-          'CONSUL_SERVICE_COUNT',
-          Math.floor(
-            (
-              Math.random() * env('CONSUL_SERVICE_MAX', 10)
-            ) + parseInt(env('CONSUL_SERVICE_MIN', 1))
-          )
-        )
+        serviceCount
       ).map((item, i) => `
     {
       "Name": "service-${i}",
-      "Datacenter": "${fake.helpers.randomize(['dc-1', 'dc-2', 'dc-3'])}",
+  ${i % 2 ? `
+      "Datacenter": "${dc}",
+  ` : `
+      "Datacenter": "${fake.address.countryCode().toLowerCase()}_${ i % 2 ? "west" : "east"}-${i}",
+  `}
   ${i === 1 ? `
         "Namespace": "default",
   ` : `
@@ -46,7 +55,12 @@
       ).map((item, i) => `
     {
       "Name": "service-${i}",
-      "Datacenter": "${fake.helpers.randomize(['dc-1', 'dc-2', 'dc-3'])}",
+  ${i % 2 ? `
+      "Datacenter": "${dc}",
+  ` : `
+      "Datacenter": "${fake.address.countryCode().toLowerCase()}_${ i % 2 ? "west" : "east"}-${i}",
+  `}
+
   ${i === 1 ? `
         "Namespace": "default",
   ` : `
@@ -63,4 +77,7 @@
     }
       `)}
   ]
+}`
+
+  })
 }


### PR DESCRIPTION
The topology endpoint now returns the same datacenter as the current Service in every other object.