### PR TITLE
Add a latency for metrics queries

### DIFF
--- a/v1/internal/ui/metrics-proxy/api/v1/.config
+++ b/v1/internal/ui/metrics-proxy/api/v1/.config
@@ -1,0 +1,5 @@
+---
+"*":
+  GET:
+    "*":
+      latency: ${env('CONSUL_LATENCY', 0)}

--- a/v1/internal/ui/metrics-proxy/api/v1/query
+++ b/v1/internal/ui/metrics-proxy/api/v1/query
@@ -1,4 +1,3 @@
-
 {
   "status": "success",
   "data": {


### PR DESCRIPTION
This enables us to set the how long it takes for the query responses to come back via the `CONSUL_LATENCY` cookie