### PR TITLE
Add predictable, overridable local DC

### DIFF
--- a/v1/catalog/datacenters
+++ b/v1/catalog/datacenters
@@ -1,6 +1,7 @@
 [
+  "${env('CONSUL_DATACENTER_LOCAL', 'dc1')}",
   ${
-    range(env('CONSUL_DATACENTER_COUNT', 10)).map(
+    range(env('CONSUL_DATACENTER_COUNT', 10)-1).map(
         function(item, i) {
             return `"${fake.address.countryCode().toLowerCase()}_${ i % 2 ? "west" : "east"}-${i}"`;
         }


### PR DESCRIPTION
This ensures that the datacenters endpoint always returns the local DC first as it would in Consul.

This is needed as this is soon going to passed as an ENV var and the UI in test mode needs to behave like the real thing with the local DC actually matching the one the UI loads by default from the DCs endpoint.