### PR TITLE
Add HasExact to service-topology response

### DIFF
--- a/v1/internal/ui/service-topology/_
+++ b/v1/internal/ui/service-topology/_
@@ -73,7 +73,8 @@ ${
       "Intention": {
         "Allowed": ${allowed},
         "HasPermissions": ${hasPerms},
-        "ExternalSource": "${fake.helpers.randomize(['nomad', 'kubernetes', ''])}"
+        "ExternalSource": "${fake.helpers.randomize(['nomad', 'kubernetes', ''])}",
+        "HasExact": ${fake.random.boolean()}
       }
     }
     `})}
@@ -100,7 +101,8 @@ ${
       "Intention": {
         "Allowed": ${allowed},
         "HasPermissions": ${hasPerms},
-        "ExternalSource": "${fake.helpers.randomize(['nomad', 'kubernetes', ''])}"
+        "ExternalSource": "${fake.helpers.randomize(['nomad', 'kubernetes', ''])}",
+        "HasExact": ${fake.random.boolean()}
       }
     }
     `})}


### PR DESCRIPTION
Following the BE changes merged in [PR 9010](https://github.com/hashicorp/consul/pull/9010). 
- HasExact lives in the Intention object.
- HasExact is independent of the other flags.