### PR TITLE
Actually fixup datacenters

### DIFF
--- a/v1/catalog/datacenters
+++ b/v1/catalog/datacenters
@@ -1,9 +1,12 @@
 [
-  "${env('CONSUL_DATACENTER_LOCAL', 'dc1')}"
   ${
-    range(env('CONSUL_DATACENTER_COUNT', 10)-1).map(
-        function(item, i) {
-            return `,"${fake.address.countryCode().toLowerCase()}_${ i % 2 ? "west" : "east"}-${i}"`;
+    range(env('CONSUL_DATACENTER_COUNT', 10)).map((item, i) => {
+      if(i === 0) {
+        return `"dc1"`;
+      }
+      return `
+        "${fake.address.countryCode().toLowerCase()}_${ i % 2 ? "west" : "east"}-${i}"
+`;
         }
     )
   }


### PR DESCRIPTION
The previous PR to fix datacenters didn't take into account the commas added via `map`. This takes an easier to read approach to output `dc1` on first iteration of the `map`.